### PR TITLE
feat: Publish game artifacts during the build, run only the executable for demo runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   build:
     name: Build
-    runs-on: windows-latest-32-cores
+    runs-on: windows-latest
 
     steps:
       - name: Log in to GitHub package registry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   build:
     name: Build
-    runs-on: windows-latest
+    runs-on: windows-latest-32-cores
 
     steps:
       - name: Log in to GitHub package registry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,9 +49,9 @@ jobs:
             -package `
             -archive
 
-      - name: Upload SentryTower.exe
+      - name: Upload SentryTower
         uses: actions/upload-artifact@v4
         with:
           name: SentryTower
-          path: checkout/Builds/Windows/SentryTower.exe
+          path: checkout/Builds/Windows/
           retention-days: 90

--- a/.github/workflows/run-demo.yml
+++ b/.github/workflows/run-demo.yml
@@ -36,14 +36,29 @@ jobs:
             exit 1
           }
           
+          # List all files in download path
+          Write-Output "Files in download path:"
+          Get-ChildItem $downloadPath -Recurse
+          
           $exePath = Join-Path $downloadPath "SentryTower.exe"
+          Write-Output "Looking for executable at: $exePath"
+          
           if (!(Test-Path $exePath)) {
             Write-Error "SentryTower.exe not found at: $exePath"
             exit 1
           }
           
-          Write-Output "Running: $exePath -Unattended -nullrhi --idle"
-          $output = & $exePath -Unattended -nullrhi --idle 2>&1
-          Write-Output "Game console output:"
-          Write-Output $output
-          Write-Output "Exit code: $LASTEXITCODE"
+          # Check file properties
+          $fileInfo = Get-Item $exePath
+          Write-Output "File size: $($fileInfo.Length) bytes"
+          Write-Output "File exists: $(Test-Path $exePath)"
+          
+          Write-Output "Running: `"$exePath`" -Unattended -nullrhi --idle"
+          try {
+            $output = & $exePath -Unattended -nullrhi --idle 2>&1
+            Write-Output "Game console output:"
+            Write-Output $output
+            Write-Output "Exit code: $LASTEXITCODE"
+          } catch {
+            Write-Error "Failed to execute: $($_.Exception.Message)"
+          }

--- a/.github/workflows/run-demo.yml
+++ b/.github/workflows/run-demo.yml
@@ -27,31 +27,22 @@ jobs:
           repository: ${{ github.repository }}
           run-id: ${{ steps.get-run.outputs.run-id }}
 
-      - name: Extract artifact
+      - name: Run simulation
         run: |
           $downloadPath = "${{ steps.download.outputs.download-path }}"
           Write-Output "Download path: $downloadPath"
-          
-          # List files in download path
-          Get-ChildItem -Path $downloadPath
-          
-          # Find the zip file
-          $zipFile = Get-ChildItem -Path $downloadPath -Filter "*.zip" | Select-Object -First 1
-          if (!$zipFile) {
-            Write-Error "No zip file found in download path: $downloadPath"
+          if (!(Test-Path $downloadPath)) {
+            Write-Error "Download path does not exist: $downloadPath"
             exit 1
           }
           
-          Write-Output "Extracting: $($zipFile.Name)"
-          Expand-Archive -Path $zipFile.FullName -DestinationPath "." -Force
-
-      - name: Run simulation
-        run: |
-          if (!(Test-Path "SentryTower.exe")) {
-            Write-Error "SentryTower.exe not found after extraction"
+          $exePath = Join-Path $downloadPath "SentryTower.exe"
+          if (!(Test-Path $exePath)) {
+            Write-Error "SentryTower.exe not found at: $exePath"
             exit 1
           }
-          .\SentryTower.exe -Unattended -nullrhi --idle
+          
+          & $exePath -Unattended -nullrhi --idle
           if ($LASTEXITCODE -eq 0) {
             Write-Error "Expected non-zero exit code but got 0"
             exit 1

--- a/.github/workflows/run-demo.yml
+++ b/.github/workflows/run-demo.yml
@@ -43,8 +43,3 @@ jobs:
           }
           
           & $exePath -Unattended -nullrhi --idle
-          if ($LASTEXITCODE -eq 0) {
-            Write-Error "Expected non-zero exit code but got 0"
-            exit 1
-          }
-          Write-Output "Simulation completed with expected non-zero exit code: $LASTEXITCODE"

--- a/.github/workflows/run-demo.yml
+++ b/.github/workflows/run-demo.yml
@@ -30,46 +30,5 @@ jobs:
       - name: Run simulation
         run: |
           $downloadPath = "${{ steps.download.outputs.download-path }}"
-          Write-Output "Download path: $downloadPath"
-          if (!(Test-Path $downloadPath)) {
-            Write-Error "Download path does not exist: $downloadPath"
-            exit 1
-          }
-          
-          # List all files in download path
-          Write-Output "Files in download path:"
-          Get-ChildItem $downloadPath -Recurse
-          
-          $exePath = Join-Path $downloadPath "SentryTower.exe"
-          Write-Output "Looking for executable at: $exePath"
-          
-          if (!(Test-Path $exePath)) {
-            Write-Error "SentryTower.exe not found at: $exePath"
-            exit 1
-          }
-          
-          # Check file properties
-          $fileInfo = Get-Item $exePath
-          Write-Output "File size: $($fileInfo.Length) bytes"
-          Write-Output "File exists: $(Test-Path $exePath)"
-          
-          Write-Output "Running: `"$exePath`" -Unattended -nullrhi --idle"
-          try {
-            $process = Start-Process -FilePath $exePath -ArgumentList "-Unattended", "-nullrhi", "--idle" -Wait -PassThru -RedirectStandardOutput "output.txt" -RedirectStandardError "error.txt" -NoNewWindow
-            
-            Write-Output "Process completed with exit code: $($process.ExitCode)"
-            
-            if (Test-Path "output.txt") {
-              Write-Output "Standard Output:"
-              Get-Content "output.txt"
-            }
-            
-            if (Test-Path "error.txt") {
-              Write-Output "Standard Error:"
-              Get-Content "error.txt"
-            }
-            
-            $LASTEXITCODE = $process.ExitCode
-          } catch {
-            Write-Error "Failed to execute: $($_.Exception.Message)"
-          }
+          Write-Output "Download path: $downloadPath"          
+          docker run --rm -v "${downloadPath}:C:\app" mcr.microsoft.com/windows/server:ltsc2022 cmd /c "cd C:\app && SentryTower.exe -Unattended -nullrhi --idle"

--- a/.github/workflows/run-demo.yml
+++ b/.github/workflows/run-demo.yml
@@ -55,10 +55,21 @@ jobs:
           
           Write-Output "Running: `"$exePath`" -Unattended -nullrhi --idle"
           try {
-            $output = & $exePath -Unattended -nullrhi --idle 2>&1
-            Write-Output "Game console output:"
-            Write-Output $output
-            Write-Output "Exit code: $LASTEXITCODE"
+            $process = Start-Process -FilePath $exePath -ArgumentList "-Unattended", "-nullrhi", "--idle" -Wait -PassThru -RedirectStandardOutput "output.txt" -RedirectStandardError "error.txt" -NoNewWindow
+            
+            Write-Output "Process completed with exit code: $($process.ExitCode)"
+            
+            if (Test-Path "output.txt") {
+              Write-Output "Standard Output:"
+              Get-Content "output.txt"
+            }
+            
+            if (Test-Path "error.txt") {
+              Write-Output "Standard Error:"
+              Get-Content "error.txt"
+            }
+            
+            $LASTEXITCODE = $process.ExitCode
           } catch {
             Write-Error "Failed to execute: $($_.Exception.Message)"
           }

--- a/.github/workflows/run-demo.yml
+++ b/.github/workflows/run-demo.yml
@@ -19,23 +19,26 @@ jobs:
           echo "run-id=$runId" >> $env:GITHUB_OUTPUT
 
       - name: Download SentryTower
+        id: download
         uses: actions/download-artifact@v4
         with:
           name: SentryTower
-          path: ./artifacts
           github-token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}
           run-id: ${{ steps.get-run.outputs.run-id }}
 
       - name: Extract artifact
         run: |
-          # List downloaded files for debugging
-          Get-ChildItem -Path "./artifacts" -Filter "*.zip"
+          $downloadPath = "${{ steps.download.outputs.download-path }}"
+          Write-Output "Download path: $downloadPath"
+          
+          # List files in download path
+          Get-ChildItem -Path $downloadPath
           
           # Find the zip file
-          $zipFile = Get-ChildItem -Path "./artifacts" -Filter "*.zip" | Select-Object -First 1
+          $zipFile = Get-ChildItem -Path $downloadPath -Filter "*.zip" | Select-Object -First 1
           if (!$zipFile) {
-            Write-Error "No zip file found in artifacts directory"
+            Write-Error "No zip file found in download path: $downloadPath"
             exit 1
           }
           

--- a/.github/workflows/run-demo.yml
+++ b/.github/workflows/run-demo.yml
@@ -42,4 +42,8 @@ jobs:
             exit 1
           }
           
-          & $exePath -Unattended -nullrhi --idle
+          Write-Output "Running: $exePath -Unattended -nullrhi --idle"
+          $output = & $exePath -Unattended -nullrhi --idle 2>&1
+          Write-Output "Game console output:"
+          Write-Output $output
+          Write-Output "Exit code: $LASTEXITCODE"

--- a/.github/workflows/run-demo.yml
+++ b/.github/workflows/run-demo.yml
@@ -22,17 +22,25 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: SentryTower
+          path: ./artifacts
           github-token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}
           run-id: ${{ steps.get-run.outputs.run-id }}
 
       - name: Extract artifact
         run: |
-          if (!(Test-Path "SentryTower.zip")) {
-            Write-Error "SentryTower.zip not found"
+          # List downloaded files for debugging
+          Get-ChildItem -Path "./artifacts" -Filter "*.zip"
+          
+          # Find the zip file
+          $zipFile = Get-ChildItem -Path "./artifacts" -Filter "*.zip" | Select-Object -First 1
+          if (!$zipFile) {
+            Write-Error "No zip file found in artifacts directory"
             exit 1
           }
-          Expand-Archive -Path "SentryTower.zip" -DestinationPath "." -Force
+          
+          Write-Output "Extracting: $($zipFile.Name)"
+          Expand-Archive -Path $zipFile.FullName -DestinationPath "." -Force
 
       - name: Run simulation
         run: |

--- a/.github/workflows/run-demo.yml
+++ b/.github/workflows/run-demo.yml
@@ -43,9 +43,9 @@ jobs:
           }
           
           Write-Output "Running: $exePath -Unattended -nullrhi --idle"
-          & $exePath -Unattended -nullrhi --idle
-          $exitCode = $LASTEXITCODE
-          Write-Output "Exit code: $exitCode"
+          $process = Start-Process -FilePath $exePath -ArgumentList "-Unattended", "-nullrhi", "--idle" -Wait -PassThru -NoNewWindow
+          $exitCode = $process.ExitCode
+          Write-Output "Process completed. Exit code: $exitCode"
           
           if ($exitCode -eq 0) {
             Write-Error "Expected non-zero exit code but got 0"

--- a/.github/workflows/run-demo.yml
+++ b/.github/workflows/run-demo.yml
@@ -27,8 +27,16 @@ jobs:
           repository: ${{ github.repository }}
           run-id: ${{ steps.get-run.outputs.run-id }}
 
-      - name: Run simulation
+      - name: Start Windows Docker Container
         run: |
           $downloadPath = "${{ steps.download.outputs.download-path }}"
-          Write-Output "Download path: $downloadPath"          
-          docker run --rm -v "${downloadPath}:C:\app" mcr.microsoft.com/windows/server:ltsc2022 cmd /c "cd C:\app && SentryTower.exe -Unattended -nullrhi --idle"
+          Write-Output "Download path: $downloadPath"
+          docker run -td `
+            --name unreal `
+            --volume "${downloadPath}:C:\workspace" `
+            --workdir C:\workspace `
+            mcr.microsoft.com/windows/server:ltsc2022
+      
+      - name: Run Simulation
+        run: |
+          docker exec unreal C:\workspace\SentryTower.exe -Unattended -nullrhi --idle

--- a/.github/workflows/run-demo.yml
+++ b/.github/workflows/run-demo.yml
@@ -18,7 +18,7 @@ jobs:
           $runId = $runs.workflow_runs[0].id
           echo "run-id=$runId" >> $env:GITHUB_OUTPUT
 
-      - name: Download SentryTower.exe
+      - name: Download SentryTower
         uses: actions/download-artifact@v4
         with:
           name: SentryTower
@@ -26,8 +26,20 @@ jobs:
           repository: ${{ github.repository }}
           run-id: ${{ steps.get-run.outputs.run-id }}
 
+      - name: Extract artifact
+        run: |
+          if (!(Test-Path "SentryTower.zip")) {
+            Write-Error "SentryTower.zip not found"
+            exit 1
+          }
+          Expand-Archive -Path "SentryTower.zip" -DestinationPath "." -Force
+
       - name: Run simulation
         run: |
+          if (!(Test-Path "SentryTower.exe")) {
+            Write-Error "SentryTower.exe not found after extraction"
+            exit 1
+          }
           .\SentryTower.exe -Unattended -nullrhi --idle
           if ($LASTEXITCODE -eq 0) {
             Write-Error "Expected non-zero exit code but got 0"

--- a/.github/workflows/run-demo.yml
+++ b/.github/workflows/run-demo.yml
@@ -27,16 +27,28 @@ jobs:
           repository: ${{ github.repository }}
           run-id: ${{ steps.get-run.outputs.run-id }}
 
-      - name: Start Windows Docker Container
+      - name: Run Simulation
         run: |
           $downloadPath = "${{ steps.download.outputs.download-path }}"
           Write-Output "Download path: $downloadPath"
-          docker run -td `
-            --name unreal `
-            --volume "${downloadPath}:C:\workspace" `
-            --workdir C:\workspace `
-            mcr.microsoft.com/windows/server:ltsc2022
-      
-      - name: Run Simulation
-        run: |
-          docker exec unreal C:\workspace\SentryTower.exe -Unattended -nullrhi --idle
+          
+          # List files in download path
+          Write-Output "Files in download path:"
+          Get-ChildItem $downloadPath
+          
+          $exePath = Join-Path $downloadPath "SentryTower.exe"
+          if (!(Test-Path $exePath)) {
+            Write-Error "SentryTower.exe not found at: $exePath"
+            exit 1
+          }
+          
+          Write-Output "Running: $exePath -Unattended -nullrhi --idle"
+          & $exePath -Unattended -nullrhi --idle
+          $exitCode = $LASTEXITCODE
+          Write-Output "Exit code: $exitCode"
+          
+          if ($exitCode -eq 0) {
+            Write-Error "Expected non-zero exit code but got 0"
+            exit 1
+          }
+          Write-Output "Simulation completed with expected non-zero exit code: $exitCode"


### PR DESCRIPTION
* Currently building/releasing the Demo game takes ~2 hours
* We needed a better way to execute the game quickly for the Demo/Sandbox
* Split the build into two parts: build + package + upload and download + run
* Use Github actions to manage files