### PR TITLE
Add debug symbol upload to Sentry in CI workflow (#2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.PAT_TOKEN }}
 
       - name: Start Docker container
         run: |
@@ -36,6 +36,8 @@ jobs:
           submodules: recursive
 
       - name: Build game
+        env:
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         run: |
           docker exec unreal C:\UnrealEngine\Engine\Build\BatchFiles\RunUAT.bat BuildCookRun `
             -project=C:\workspace\checkout\SentryTower.uproject `
@@ -48,6 +50,21 @@ jobs:
             -prereqss `
             -package `
             -archive
+
+      - name: Upload debug symbols to Sentry
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+        run: |
+          docker exec unreal C:\workspace\checkout\Plugins\Sentry\Scripts\upload-debug-symbols-win.bat `
+            Win64 `
+            SentryTower `
+            Game `
+            Development `
+            C:\workspace\checkout `
+            C:\workspace\checkout\Plugins\Sentry
 
       - name: Run simulation
         run: |


### PR DESCRIPTION
* Add debug symbol upload to Sentry in CI workflow

* Switch to PAT_TOKEN for container registry authentication

* Add SENTRY_DSN environment variable from GitHub secrets