### PR TITLE
Enable network performance metrics in demo simulation

### DIFF
--- a/.github/workflows/run-demo.yml
+++ b/.github/workflows/run-demo.yml
@@ -44,11 +44,21 @@ jobs:
             exit 1
           }
           
+          # Start a dummy spectator client in the background to emulate multiplayer setup required for network traffic generation
+          Write-Output "Starting spectator client..."
+          $client = Start-Process -FilePath $exePath -ArgumentList "-Unattended", "-nullrhi", "127.0.0.1:7777" -PassThru -NoNewWindow
+
+          # Run game as a listen server to which the spectator client can connect
           Write-Output "Running: $exePath -Unattended -nullrhi --idle"
-          $process = Start-Process -FilePath $exePath -ArgumentList "-Unattended", "-nullrhi", "--idle" -Wait -PassThru -NoNewWindow
-          $exitCode = $process.ExitCode
+          $server = Start-Process -FilePath $exePath -ArgumentList "-Unattended", "-nullrhi", "--idle", "/Game/Maps/Main?listen", "-port=7777" -Wait -PassThru -NoNewWindow
+          $exitCode = $server.ExitCode
           Write-Output "Process completed. Exit code: $exitCode"
-          
+
+          if (!$client.HasExited) {
+            Write-Output "Stopping spectator client..."
+            Stop-Process -Id $client.Id -Force -ErrorAction SilentlyContinue
+          }
+
           if ($exitCode -eq 0) {
             Write-Error "Expected non-zero exit code but got 0"
             exit 1

--- a/Config/DefaultEngine.ini
+++ b/Config/DefaultEngine.ini
@@ -299,7 +299,11 @@ EnableMetrics=True
 EnableAutoFrameTimeMetrics=True
 EnableAutoGameStatsMetrics=True
 EnableAutoGCMetrics=True
+EnableAutoNetworkMetrics=True
 GameStatsSampleInterval=15
+
+[SystemSettings]
+net.EnableNetStats=1
 
 [/Script/MacTargetPlatform.MacTargetSettings]
 -TargetedRHIs=SF_METAL_SM5


### PR DESCRIPTION
This PR configures the tower defense demo to emit Sentry network performance metrics during CI simulation runs.                          
                                                                                                                                           
Changes:                                                                                                                                 
- Enable `EnableAutoNetworkMetrics` and `net.EnableNetStats` in `DefaultEngine.ini`
- Launch the game as a listen server with a dummy spectator client to generate real network traffic
- Server runs in idle mode on `/Game/Maps/Main?listen`, client connects as a background spectator
- Client is automatically cleaned up when the server exits