### PR TITLE
chore: Clean up CI output log

### DIFF
--- a/.github/workflows/run-demo.yml
+++ b/.github/workflows/run-demo.yml
@@ -46,7 +46,7 @@ jobs:
           
           # Start a dummy spectator client in the background to emulate multiplayer setup required for network traffic generation
           Write-Output "Starting spectator client..."
-          $client = Start-Process -FilePath $exePath -ArgumentList "-Unattended", "-nullrhi", "127.0.0.1:7777" -PassThru -NoNewWindow
+          $client = Start-Process -FilePath $exePath -ArgumentList "-Unattended", "-nullrhi", "127.0.0.1:7777" -PassThru -WindowStyle Hidden
 
           # Run game as a listen server to which the spectator client can connect
           Write-Output "Running: $exePath -Unattended -nullrhi --idle"

--- a/Config/DefaultEngine.ini
+++ b/Config/DefaultEngine.ini
@@ -301,6 +301,8 @@ EnableAutoGameStatsMetrics=True
 EnableAutoGCMetrics=True
 EnableAutoNetworkMetrics=True
 GameStatsSampleInterval=15
+EnableOnCrashLogging=True
+Debug=False
 
 [SystemSettings]
 net.EnableNetStats=1


### PR DESCRIPTION
Changes:
- Suppress log output of spectator client process
- Disable internal debug logs