### PR TITLE
Fix automatic log capturing configuration

### DIFF
--- a/Config/DefaultEngine.ini
+++ b/Config/DefaultEngine.ini
@@ -303,6 +303,7 @@ EnableAutoNetworkMetrics=True
 GameStatsSampleInterval=15
 EnableOnCrashLogging=True
 Debug=False
+StructuredLoggingLevels=(bOnFatalLog=True,bOnErrorLog=True,bOnWarningLog=True,bOnInfoLog=False,bOnDebugLog=False)
 
 [SystemSettings]
 net.EnableNetStats=1

--- a/Plugins/Sentry/Sentry.uplugin
+++ b/Plugins/Sentry/Sentry.uplugin
@@ -1,5 +1,5 @@
 {
-	"EngineVersion" : "5.8.0",
+	"EngineVersion" : "5.7.0",
 	"FileVersion": 3,
 	"Version": 1,
 	"VersionName": "1.15.0",


### PR DESCRIPTION
Making structured logs an opt-out feature (https://github.com/getsentry/sentry-unreal/pull/1371) also disabled automatic log capturing for warnings/errors/fatal messages which now has to be configured explicitly.