### PR TITLE
Drop fragile libc6-dbg install from Linux demo run

### DIFF
--- a/.github/workflows/run-linux.yml
+++ b/.github/workflows/run-linux.yml
@@ -33,20 +33,20 @@ jobs:
           sparse-checkout-cone-mode: false
           path: repo
 
-      - name: Upload system libc debug info
-        # Symbolicate native crash frames in the runner's libc: libc6-dbg supplies
-        # symbols, the runtime .so supplies unwind info (matched by GNU build-id).
+      - name: Upload system libc for crash symbolication
+        # The runtime .so carries the GNU build-id and unwind info Sentry needs to
+        # process libc frames in crash reports. Full debug symbols (libc6-dbg) would
+        # only improve naming inside libc frames, and installing them pinned to the
+        # runner's libc version breaks whenever the apt archive moves on.
         env:
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
           set -euo pipefail
-          sudo apt-get update
-          sudo apt-get install -y "libc6-dbg=$(dpkg-query -W -f='${Version}' libc6)"
           CLI=repo/Plugins/Sentry/Source/ThirdParty/CLI/sentry-cli-Linux-x86_64
           chmod +x "$CLI"
-          "$CLI" debug-files upload /usr/lib/debug /lib/x86_64-linux-gnu/libc.so.6
+          "$CLI" debug-files upload /lib/x86_64-linux-gnu/libc.so.6
 
       - name: Run Simulation
         env:


### PR DESCRIPTION
The version-pinned `apt-get install libc6-dbg=<installed libc6 version>` in the Linux demo run breaks whenever the runner image and the apt archive drift apart. Since 2026-07-27 ~15:48 UTC every scheduled run fails with:

```
Package libc6-dbg is not available, but is referred to by another package.
E: Version '2.39-0ubuntu8.7' for 'libc6-dbg' was not found
```

This keeps the part of #30 that matters — uploading the runner's `/lib/x86_64-linux-gnu/libc.so.6`, which carries the GNU build-id and unwind info Sentry needs to process libc frames in crash reports — and drops the apt install entirely. The dbg package only improved frame naming inside libc; if we miss it, we can revisit with a fallback-tolerant install instead of a hard pin.