### PR TITLE
Package self-contained Windows demo build for UE 5.8

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -49,7 +49,10 @@ jobs:
             -stage `
             -prereqs `
             -package `
-            -archive
+            -archive `
+            -pak `
+            -iostore `
+            -nozenstore
 
       - name: Upload SentryTower
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7


### PR DESCRIPTION
## Problem

The scheduled **Run Demo (Windows)** job has been failing since the UE 5.8 upgrade (#35) with:

```
Write-Error: Expected non-zero exit code but got 0
##[error]Process completed with exit code 1
```

### Root cause

PR #35's only change to `build-windows.yml` was bumping `UE_VERSION` 5.7 → 5.8; the `BuildCookRun` command was unchanged. But **UE 5.8 makes Zen Store streaming the default** for staging. The same `-cook -stage -package -archive` command that produced embedded pak/iostore containers under 5.7 now produces a **content-less stub**: a ~170 KB `SentryTower.exe` plus a `ue.projectstore` descriptor pointing at the *build* machine's Zen storage server.

The Run Demo job runs on a **separate** runner with no Zen server, so at runtime the game spends ~50s retrying dead addresses and gives up:

```
LogCsvProfiler: Metadata set : zenstreaming="1"
LogStorageServerConnection: Send to storage server failed (peer likely closed the connection) ...
LogStorageServerPlatformFile: Error: Failed to initialize connection to any of [ [::1], 172.25.89.228, ...cloudapp.net ]
```

With no content loaded, the game never reaches the intended Sentry crash and exits `0`, tripping the test's non-zero-exit guard.

## Fix

Add `-pak -iostore -nozenstore` to `BuildCookRun` so cooked content is embedded in the package and the uploaded artifact is standalone again.

## Verification (local, UE 5.8)

Built with the new flags and ran the game exactly as the CI Run Demo step does:

- ✅ No `ue.projectstore` stub; content embedded as real containers (`SentryTower-Windows.ucas` ≈ 259 MB, `.pak` ≈ 11 MB, `.utoc`, global containers)
- ✅ Runtime log shows `zenstreaming="0"` (was `"1"`) and **zero** storage-server connection failures
- ✅ Game loaded content and exited with code **3** — the intended crash — so the CI assertion passes

## Notes

The Linux and Android build workflows share the same `BuildCookRun` pattern and are likely affected the same way post-5.8; those aren't touched here so this change can be verified in isolation first.