### PR TITLE
Add macOS build/run demo workflows

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -61,6 +61,7 @@ jobs:
             -archivedirectory="$GITHUB_WORKSPACE/checkout/Builds" \
             -platform=Mac \
             -UBTArgs="-AllCores" \
+            -AdditionalCookerOptions="-skipminspeccheck" \
             -nop4 \
             -cook \
             -build \

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -1,0 +1,86 @@
+name: Build Demo (macOS)
+
+on:
+  workflow_call:
+
+env:
+  REGISTRY: ghcr.io
+  UE_VERSION: 5.8
+
+jobs:
+  build:
+    name: Build macOS
+    runs-on: macos-latest
+    timeout-minutes: 360
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          path: checkout
+          submodules: recursive
+
+      - name: Install oras
+        uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2.0.1
+
+      - name: Download Unreal Engine
+        # The pre-built macOS engine is published as split zip parts in the OCI
+        # registry (see getsentry/sentry-unreal ue-oci-macos.yml).
+        env:
+          GH_USERNAME: ${{ secrets.GH_USERNAME }}
+          PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+        run: |
+          echo "$PAT_TOKEN" | oras login "$REGISTRY" -u "$GH_USERNAME" --password-stdin
+          # Retry the pull - the runner's network occasionally drops connections mid-download
+          for attempt in 1 2 3; do
+            oras pull "$REGISTRY/getsentry/unreal-docker:$UE_VERSION-mac" && break
+            [ "$attempt" = 3 ] && exit 1
+            rm -f ue.zip.part-*
+            sleep 10
+          done
+          cat ue.zip.part-* > ue.zip
+          rm ue.zip.part-*
+
+      - name: Install Unreal Engine
+        run: |
+          mkdir -p "$HOME/UnrealEngine"
+          unzip -q ue.zip -d "$HOME/UnrealEngine"
+          rm ue.zip
+          UE_ROOT="$HOME/UnrealEngine"
+          echo "UE_ROOT=$UE_ROOT" >> "$GITHUB_ENV"
+          # Zip archives may not preserve execute permissions
+          chmod -R u+x "$UE_ROOT/Engine/Build/BatchFiles" "$UE_ROOT/Engine/Binaries" || true
+
+      - name: Build game
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+        run: |
+          "$UE_ROOT/Engine/Build/BatchFiles/RunUAT.sh" BuildCookRun \
+            -project="$GITHUB_WORKSPACE/checkout/SentryTower.uproject" \
+            -archivedirectory="$GITHUB_WORKSPACE/checkout/Builds" \
+            -platform=Mac \
+            -UBTArgs="-AllCores" \
+            -nop4 \
+            -cook \
+            -build \
+            -stage \
+            -package \
+            -archive \
+            -pak \
+            -iostore \
+            -nozenstore
+
+      - name: Collect build logs on failure
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        with:
+          name: SentryTower-Mac-build-logs
+          path: checkout/Saved/Logs
+
+      - name: Upload SentryTower
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        with:
+          name: SentryTower-Mac
+          path: checkout/Builds/Mac/
+          retention-days: 90

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,10 @@ jobs:
     uses: ./.github/workflows/build-linux.yml
     secrets: inherit
 
+  build-macos:
+    uses: ./.github/workflows/build-macos.yml
+    secrets: inherit
+
   build-android:
     uses: ./.github/workflows/build-android.yml
     secrets: inherit

--- a/.github/workflows/run-demo.yml
+++ b/.github/workflows/run-demo.yml
@@ -13,6 +13,7 @@ on:
           - all
           - windows
           - linux
+          - macos
           - android
 
 concurrency:
@@ -28,6 +29,11 @@ jobs:
   run-linux:
     if: ${{ github.event_name != 'workflow_dispatch' || contains(fromJSON('["all","linux"]'), inputs.platforms) }}
     uses: ./.github/workflows/run-linux.yml
+    secrets: inherit
+
+  run-macos:
+    if: ${{ github.event_name != 'workflow_dispatch' || contains(fromJSON('["all","macos"]'), inputs.platforms) }}
+    uses: ./.github/workflows/run-macos.yml
     secrets: inherit
 
   run-android:

--- a/.github/workflows/run-macos.yml
+++ b/.github/workflows/run-macos.yml
@@ -1,0 +1,66 @@
+name: Run Demo (macOS)
+
+on:
+  workflow_call:
+
+jobs:
+  run:
+    name: Run Demo (macOS)
+    runs-on: macos-latest
+
+    steps:
+      - name: Get latest build run
+        id: get-run
+        shell: pwsh
+        run: |
+          $runs = Invoke-RestMethod -Uri "https://api.github.com/repos/${{ github.repository }}/actions/workflows/ci.yml/runs?status=success&per_page=1" -Headers @{Authorization="Bearer ${{ secrets.GITHUB_TOKEN }}"}
+          $runId = $runs.workflow_runs[0].id
+          echo "run-id=$runId" >> $env:GITHUB_OUTPUT
+
+      - name: Download SentryTower
+        id: download
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: SentryTower-Mac
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          run-id: ${{ steps.get-run.outputs.run-id }}
+
+      - name: Run Simulation
+        env:
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+        run: |
+          DL="${{ steps.download.outputs.download-path }}"
+          echo "Download path: $DL"
+          ls "$DL"
+
+          # The artifact zip round-trip strips the unix execute bit
+          chmod -R +x "$DL"
+
+          APP_BIN="$(find "$DL" -type f -path '*/SentryTower.app/Contents/MacOS/SentryTower' | head -n 1)"
+          if [ -z "$APP_BIN" ]; then
+            echo "::error::SentryTower.app was not found in: $DL"
+            exit 1
+          fi
+          echo "App binary: $APP_BIN"
+
+          # Start a dummy spectator client in the background to emulate multiplayer setup required for network traffic generation
+          echo "Starting spectator client..."
+          "$APP_BIN" -Unattended -nullrhi 127.0.0.1:7777 &
+          CLIENT_PID=$!
+
+          # Run game as a listen server to which the spectator client can connect
+          echo "Running: SentryTower -Unattended -nullrhi --idle"
+          set +e
+          "$APP_BIN" -Unattended -nullrhi --idle "/Game/Maps/Main?listen" -port=7777
+          EXIT_CODE=$?
+          set -e
+          echo "Process completed. Exit code: $EXIT_CODE"
+
+          kill $CLIENT_PID 2>/dev/null || true
+
+          if [ $EXIT_CODE -eq 0 ]; then
+            echo "::error::Expected non-zero exit code but got 0"
+            exit 1
+          fi
+          echo "Simulation completed with expected non-zero exit code: $EXIT_CODE"


### PR DESCRIPTION
## Summary

Adds macOS build and run workflows for the SentryTower demo, mirroring the existing Windows/Linux pairs.

- **`build-macos.yml`** - pulls the pre-built engine from the OCI registry (`oras pull ghcr.io/getsentry/unreal-docker:5.8-mac`, reassembling the split zip parts), installs it to `$HOME/UnrealEngine`, then `BuildCookRun -platform=Mac` and uploads the `SentryTower-Mac` artifact.
- **`run-macos.yml`** - downloads the latest successful `SentryTower-Mac` artifact, locates the `.app` binary, and runs the spectator-client + listen-server simulation, asserting the expected non-zero (crash) exit.
- Wired `build-macos` into `ci.yml` and `run-macos` into `run-demo.yml` (with a new `macos` dispatch option).

## Notes

- `-AdditionalCookerOptions="-skipminspeccheck"` avoids the cooker hanging on the runner's min-spec (Metal feature-level) probe.